### PR TITLE
Update 36_Double-base-palindromes.js

### DIFF
--- a/36_Double-base-palindromes.js
+++ b/36_Double-base-palindromes.js
@@ -1,30 +1,38 @@
 function processData(input) 
 {
-    var n = input.split(' ')[0];
-    var k = input.split(' ')[1];
+    // Convert n and k to integers
+    var n = parseInt(input.split(' ')[0]);
+    var k = parseInt(input.split(' ')[1]);
     var ans = 0;
     
-    for(var i=1; i<n; i++)
+    // Iterate from 1 to n-1
+    for(var i = 1; i < n; i++)
     {
-        var s = i + '';
+        var s = i.toString(); // Convert i to a string
 
+        // Check if the number is a palindrome in base-10
         if(s === s.split('').reverse().join(''))
         {
+            // Convert the number to base-k
             var converted = i.toString(k);
             
-            if(converted == converted.split('').reverse().join('')) ans += i; 
+            // Check if the base-k conversion is a palindrome
+            if(converted === converted.split('').reverse().join('')) 
+                ans += i; // Add the number to the result if both conditions are met
         }
     }
-    console.log(ans);
+    
+    console.log(ans); // Output the result
 } 
 
+// Handling input from stdin
 process.stdin.resume();
 process.stdin.setEncoding("ascii");
-_input = "";
+let _input = "";
 process.stdin.on("data", function (input) {
     _input += input;
 });
 
 process.stdin.on("end", function () {
-   processData(_input);
+   processData(_input); // Process the input once it ends
 });


### PR DESCRIPTION
There is a bug in the JavaScript code due to the way the variables n and k are extracted and used. Both are initially extracted as strings from the input, but they should be converted to numbers before using them in calculations or loops. Specifically:

n is used in a loop, but it's a string, so it needs to be converted to a number. k is used in the toString(k) method to convert numbers to base k, but it also needs to be converted to a number. Changes made:
Convert n and k to integers: The original code treats them as strings, which would cause issues. The parseInt() function is used to convert them to numbers.

Loop over i from 1 to n-1: The loop logic remains the same, but now it will work properly since n is correctly treated as a number.

Fix base conversion and comparison: When checking if i is a palindrome in base k, it ensures the number is compared correctly as a string in both base-10 and base-k.

How it works:
The program will first check if a number is a palindrome in base-10.
If the number is a palindrome in base-10, it will then convert it to base-k and check if it's also a palindrome in that base.
If both conditions hold, the number is added to the sum.